### PR TITLE
Add heroku build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.2.1",
     "mocha": "^3.0.2"
-  }
+  },
+  "heroku-run-build-script": true
 }


### PR DESCRIPTION
Add `heroku-run-build-script: true` to all repos as part of new security requirements. If you have `heroku-postbuild` command then that will need to go on to your `build` script.